### PR TITLE
Add C++ implementation of Fasttracker core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+cpp/build/

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.12)
+project(FasttrackerCpp LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_library(fasttracker STATIC
+  src/basetrack.cpp
+  src/fasttracker.cpp
+  src/kalman_filter.cpp
+  src/matching.cpp
+  src/strack.cpp)
+
+target_include_directories(fasttracker PUBLIC include)
+

--- a/cpp/include/fasttracker/basetrack.hpp
+++ b/cpp/include/fasttracker/basetrack.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <memory>
+
+namespace fasttracker {
+
+enum class TrackState { New = 0, Tracked = 1, Lost = 2, Removed = 3 };
+
+class Fasttracker;
+
+class BaseTrack {
+ public:
+  BaseTrack();
+  virtual ~BaseTrack() = default;
+
+  int track_id() const { return track_id_; }
+  bool is_activated() const { return is_activated_; }
+  TrackState state() const { return state_; }
+  int frame_id() const { return frame_id_; }
+  int start_frame() const { return start_frame_; }
+
+  void MarkLost();
+  void MarkRemoved();
+
+ protected:
+  static int NextId();
+
+  int track_id_;
+  bool is_activated_;
+  TrackState state_;
+  int start_frame_;
+  int frame_id_;
+  int time_since_update_;
+
+  friend class Fasttracker;
+};
+
+using BaseTrackPtr = std::shared_ptr<BaseTrack>;
+
+}  // namespace fasttracker
+

--- a/cpp/include/fasttracker/fasttracker.hpp
+++ b/cpp/include/fasttracker/fasttracker.hpp
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <array>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+#include "fasttracker/matching.hpp"
+#include "fasttracker/strack.hpp"
+
+namespace fasttracker {
+
+struct FasttrackerArgs {
+  bool mot20 = false;
+};
+
+struct FasttrackerConfig {
+  double track_thresh = 0.5;
+  double match_thresh = 0.8;
+  double track_buffer = 30.0;
+  int reset_velocity_offset_occ = 5;
+  int reset_pos_offset_occ = 10;
+  double enlarge_bbox_occ = 1.05;
+  double dampen_motion_occ = 0.5;
+  int active_occ_to_lost_thresh = 10;
+  double init_iou_suppress = 0.8;
+};
+
+struct Detection {
+  std::array<double, 4> tlbr;
+  double object_score = 1.0;
+  double class_score = 1.0;
+
+  double CombinedScore() const { return object_score * class_score; }
+};
+
+class Fasttracker {
+public:
+  Fasttracker(const FasttrackerArgs &args, const FasttrackerConfig &config,
+              double frame_rate = 30.0);
+
+  std::vector<std::shared_ptr<STrack>> Update(
+      const std::vector<Detection> &output_results,
+      const std::array<int, 2> &img_info, const std::array<int, 2> &img_size);
+
+  const std::vector<std::shared_ptr<STrack>> &tracked() const {
+    return tracked_stracks_;
+  }
+
+private:
+  static bool IsOccludedBy(const std::array<double, 4> &a,
+                           const std::array<double, 4> &b, double iou_thresh);
+  static double IoU(const std::array<double, 4> &a,
+                    const std::array<double, 4> &b);
+
+  std::vector<std::shared_ptr<STrack>> tracked_stracks_;
+  std::vector<std::shared_ptr<STrack>> lost_stracks_;
+  std::vector<std::shared_ptr<STrack>> removed_stracks_;
+
+  int frame_id_ = 0;
+  FasttrackerArgs args_;
+
+  double det_thresh_;
+  double match_thresh_;
+  int buffer_size_;
+  int max_time_lost_;
+
+  int reset_velocity_offset_occ_;
+  int reset_pos_offset_occ_;
+  double enlarge_bbox_occ_;
+  double dampen_motion_occ_;
+  int active_occ_to_lost_thresh_;
+  double init_iou_suppress_;
+
+  KalmanFilter kalman_filter_;
+};
+
+std::vector<std::shared_ptr<STrack>> JointStracks(
+    const std::vector<std::shared_ptr<STrack>> &a,
+    const std::vector<std::shared_ptr<STrack>> &b);
+
+std::vector<std::shared_ptr<STrack>> SubStracks(
+    const std::vector<std::shared_ptr<STrack>> &a,
+    const std::vector<std::shared_ptr<STrack>> &b);
+
+std::pair<std::vector<std::shared_ptr<STrack>>,
+          std::vector<std::shared_ptr<STrack>>>
+RemoveDuplicateStracks(const std::vector<std::shared_ptr<STrack>> &a,
+                       const std::vector<std::shared_ptr<STrack>> &b);
+
+}  // namespace fasttracker
+

--- a/cpp/include/fasttracker/kalman_filter.hpp
+++ b/cpp/include/fasttracker/kalman_filter.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "fasttracker/linear_algebra.hpp"
+
+namespace fasttracker {
+
+struct ProjectedState {
+  std::vector<double> mean;
+  Matrix covariance;
+};
+
+class KalmanFilter {
+public:
+  KalmanFilter();
+
+  std::pair<std::vector<double>, Matrix> Initiate(
+      const std::vector<double> &measurement) const;
+
+  std::pair<std::vector<double>, Matrix> Predict(const std::vector<double> &mean,
+                                                 const Matrix &covariance) const;
+
+  std::pair<std::vector<std::vector<double>>, std::vector<Matrix>> MultiPredict(
+      const std::vector<std::vector<double>> &means,
+      const std::vector<Matrix> &covariances) const;
+
+  ProjectedState Project(const std::vector<double> &mean,
+                         const Matrix &covariance) const;
+
+  std::pair<std::vector<double>, Matrix> Update(
+      const std::vector<double> &mean, const Matrix &covariance,
+      const std::vector<double> &measurement) const;
+
+  std::vector<double> GatingDistance(
+      const std::vector<double> &mean, const Matrix &covariance,
+      const std::vector<std::vector<double>> &measurements,
+      bool only_position = false, const std::string &metric = "maha") const;
+
+  static double Chi2Inv95(int dof);
+
+private:
+  Matrix motion_mat_;
+  Matrix update_mat_;
+  double std_weight_position_;
+  double std_weight_velocity_;
+};
+
+}  // namespace fasttracker
+

--- a/cpp/include/fasttracker/linear_algebra.hpp
+++ b/cpp/include/fasttracker/linear_algebra.hpp
@@ -1,0 +1,256 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <initializer_list>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace fasttracker {
+
+class Matrix {
+public:
+  Matrix() : rows_(0), cols_(0) {}
+  Matrix(std::size_t rows, std::size_t cols)
+      : rows_(rows), cols_(cols), data_(rows * cols, 0.0) {}
+
+  Matrix(std::size_t rows, std::size_t cols, std::initializer_list<double> init)
+      : rows_(rows), cols_(cols), data_(init) {
+    if (init.size() != rows * cols) {
+      throw std::invalid_argument("Initializer size does not match matrix shape");
+    }
+  }
+
+  double &operator()(std::size_t r, std::size_t c) {
+    return data_.at(r * cols_ + c);
+  }
+
+  double operator()(std::size_t r, std::size_t c) const {
+    return data_.at(r * cols_ + c);
+  }
+
+  std::size_t rows() const { return rows_; }
+  std::size_t cols() const { return cols_; }
+
+  const std::vector<double> &data() const { return data_; }
+  std::vector<double> &data() { return data_; }
+
+  static Matrix Identity(std::size_t n) {
+    Matrix m(n, n);
+    for (std::size_t i = 0; i < n; ++i) {
+      m(i, i) = 1.0;
+    }
+    return m;
+  }
+
+  static Matrix Zeros(std::size_t rows, std::size_t cols) {
+    return Matrix(rows, cols);
+  }
+
+private:
+  std::size_t rows_;
+  std::size_t cols_;
+  std::vector<double> data_;
+};
+
+inline Matrix Diagonal(const std::vector<double> &diag) {
+  Matrix m(diag.size(), diag.size());
+  for (std::size_t i = 0; i < diag.size(); ++i) {
+    m(i, i) = diag[i];
+  }
+  return m;
+}
+
+inline Matrix Transpose(const Matrix &m) {
+  Matrix result(m.cols(), m.rows());
+  for (std::size_t r = 0; r < m.rows(); ++r) {
+    for (std::size_t c = 0; c < m.cols(); ++c) {
+      result(c, r) = m(r, c);
+    }
+  }
+  return result;
+}
+
+inline Matrix MatMul(const Matrix &a, const Matrix &b) {
+  if (a.cols() != b.rows()) {
+    throw std::invalid_argument("Matrix dimension mismatch in MatMul");
+  }
+  Matrix result(a.rows(), b.cols());
+  for (std::size_t i = 0; i < a.rows(); ++i) {
+    for (std::size_t k = 0; k < a.cols(); ++k) {
+      double aik = a(i, k);
+      if (aik == 0.0) {
+        continue;
+      }
+      for (std::size_t j = 0; j < b.cols(); ++j) {
+        result(i, j) += aik * b(k, j);
+      }
+    }
+  }
+  return result;
+}
+
+inline std::vector<double> MatVec(const Matrix &m, const std::vector<double> &v) {
+  if (m.cols() != v.size()) {
+    throw std::invalid_argument("Matrix/vector dimension mismatch in MatVec");
+  }
+  std::vector<double> result(m.rows(), 0.0);
+  for (std::size_t r = 0; r < m.rows(); ++r) {
+    double sum = 0.0;
+    for (std::size_t c = 0; c < m.cols(); ++c) {
+      sum += m(r, c) * v[c];
+    }
+    result[r] = sum;
+  }
+  return result;
+}
+
+inline std::vector<double> VecMat(const std::vector<double> &v, const Matrix &m) {
+  if (v.size() != m.rows()) {
+    throw std::invalid_argument("Vector/matrix dimension mismatch in VecMat");
+  }
+  std::vector<double> result(m.cols(), 0.0);
+  for (std::size_t c = 0; c < m.cols(); ++c) {
+    double sum = 0.0;
+    for (std::size_t r = 0; r < m.rows(); ++r) {
+      sum += v[r] * m(r, c);
+    }
+    result[c] = sum;
+  }
+  return result;
+}
+
+inline Matrix Add(const Matrix &a, const Matrix &b) {
+  if (a.rows() != b.rows() || a.cols() != b.cols()) {
+    throw std::invalid_argument("Matrix dimension mismatch in Add");
+  }
+  Matrix result(a.rows(), a.cols());
+  for (std::size_t i = 0; i < a.data().size(); ++i) {
+    result.data()[i] = a.data()[i] + b.data()[i];
+  }
+  return result;
+}
+
+inline Matrix Subtract(const Matrix &a, const Matrix &b) {
+  if (a.rows() != b.rows() || a.cols() != b.cols()) {
+    throw std::invalid_argument("Matrix dimension mismatch in Subtract");
+  }
+  Matrix result(a.rows(), a.cols());
+  for (std::size_t i = 0; i < a.data().size(); ++i) {
+    result.data()[i] = a.data()[i] - b.data()[i];
+  }
+  return result;
+}
+
+inline Matrix Outer(const std::vector<double> &a, const std::vector<double> &b) {
+  Matrix result(a.size(), b.size());
+  for (std::size_t i = 0; i < a.size(); ++i) {
+    for (std::size_t j = 0; j < b.size(); ++j) {
+      result(i, j) = a[i] * b[j];
+    }
+  }
+  return result;
+}
+
+inline Matrix Inverse(const Matrix &input) {
+  if (input.rows() != input.cols()) {
+    throw std::invalid_argument("Matrix inversion requires a square matrix");
+  }
+  std::size_t n = input.rows();
+  Matrix aug(n, 2 * n);
+  for (std::size_t r = 0; r < n; ++r) {
+    for (std::size_t c = 0; c < n; ++c) {
+      aug(r, c) = input(r, c);
+    }
+    for (std::size_t c = 0; c < n; ++c) {
+      aug(r, n + c) = (r == c) ? 1.0 : 0.0;
+    }
+  }
+
+  for (std::size_t i = 0; i < n; ++i) {
+    // Pivot selection
+    std::size_t pivot = i;
+    double max_val = std::abs(aug(i, i));
+    for (std::size_t r = i + 1; r < n; ++r) {
+      double val = std::abs(aug(r, i));
+      if (val > max_val) {
+        max_val = val;
+        pivot = r;
+      }
+    }
+    if (max_val < 1e-12) {
+      throw std::runtime_error("Matrix is singular and cannot be inverted");
+    }
+    if (pivot != i) {
+      for (std::size_t c = 0; c < 2 * n; ++c) {
+        std::swap(aug(i, c), aug(pivot, c));
+      }
+    }
+
+    double pivot_val = aug(i, i);
+    for (std::size_t c = 0; c < 2 * n; ++c) {
+      aug(i, c) /= pivot_val;
+    }
+
+    for (std::size_t r = 0; r < n; ++r) {
+      if (r == i) {
+        continue;
+      }
+      double factor = aug(r, i);
+      if (factor == 0.0) {
+        continue;
+      }
+      for (std::size_t c = 0; c < 2 * n; ++c) {
+        aug(r, c) -= factor * aug(i, c);
+      }
+    }
+  }
+
+  Matrix result(n, n);
+  for (std::size_t r = 0; r < n; ++r) {
+    for (std::size_t c = 0; c < n; ++c) {
+      result(r, c) = aug(r, n + c);
+    }
+  }
+  return result;
+}
+
+inline double Dot(const std::vector<double> &a, const std::vector<double> &b) {
+  if (a.size() != b.size()) {
+    throw std::invalid_argument("Vector dot product requires equal sizes");
+  }
+  double sum = 0.0;
+  for (std::size_t i = 0; i < a.size(); ++i) {
+    sum += a[i] * b[i];
+  }
+  return sum;
+}
+
+inline std::vector<double> Subtract(const std::vector<double> &a,
+                                    const std::vector<double> &b) {
+  if (a.size() != b.size()) {
+    throw std::invalid_argument("Vector subtraction requires equal sizes");
+  }
+  std::vector<double> result(a.size());
+  for (std::size_t i = 0; i < a.size(); ++i) {
+    result[i] = a[i] - b[i];
+  }
+  return result;
+}
+
+inline std::vector<double> Add(const std::vector<double> &a,
+                               const std::vector<double> &b) {
+  if (a.size() != b.size()) {
+    throw std::invalid_argument("Vector addition requires equal sizes");
+  }
+  std::vector<double> result(a.size());
+  for (std::size_t i = 0; i < a.size(); ++i) {
+    result[i] = a[i] + b[i];
+  }
+  return result;
+}
+
+}  // namespace fasttracker
+

--- a/cpp/include/fasttracker/matching.hpp
+++ b/cpp/include/fasttracker/matching.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "fasttracker/linear_algebra.hpp"
+#include "fasttracker/strack.hpp"
+
+namespace fasttracker {
+
+struct AssignmentResult {
+  std::vector<std::pair<int, int>> matches;
+  std::vector<int> unmatched_rows;
+  std::vector<int> unmatched_cols;
+};
+
+Matrix IouDistance(const std::vector<std::shared_ptr<STrack>> &a,
+                   const std::vector<std::shared_ptr<STrack>> &b);
+Matrix IouDistance(const std::vector<std::array<double, 4>> &a,
+                   const std::vector<std::array<double, 4>> &b);
+
+AssignmentResult LinearAssignment(const Matrix &cost_matrix, double thresh);
+
+Matrix FuseScore(const Matrix &cost_matrix,
+                 const std::vector<std::shared_ptr<STrack>> &detections);
+
+}  // namespace fasttracker
+

--- a/cpp/include/fasttracker/strack.hpp
+++ b/cpp/include/fasttracker/strack.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <array>
+#include <deque>
+#include <memory>
+#include <vector>
+
+#include "fasttracker/basetrack.hpp"
+#include "fasttracker/kalman_filter.hpp"
+
+namespace fasttracker {
+
+class Fasttracker;
+
+class STrack : public BaseTrack {
+public:
+  explicit STrack(const std::array<double, 4> &tlwh, double score);
+
+  void Predict();
+  void Activate(KalmanFilter *filter, int frame_id);
+  void ReActivate(const STrack &new_track, int frame_id, bool new_id = false);
+  void Update(const STrack &new_track, int frame_id);
+
+  const std::vector<double> &mean() const { return mean_; }
+  const Matrix &covariance() const { return covariance_; }
+  void set_mean(const std::vector<double> &mean) { mean_ = mean; }
+  void set_covariance(const Matrix &covariance) { covariance_ = covariance; }
+
+  double score() const { return score_; }
+  void set_score(double score) { score_ = score; }
+
+  std::array<double, 4> Tlwh() const;
+  std::array<double, 4> Tlbr() const;
+
+  static std::array<double, 4> TlbrToTlwh(const std::array<double, 4> &tlbr);
+  static std::array<double, 4> TlwhToTlbr(const std::array<double, 4> &tlwh);
+  static std::vector<double> TlwhToXyah(const std::array<double, 4> &tlwh);
+
+  static void MultiPredict(const std::vector<std::shared_ptr<STrack>> &tracks);
+
+  int not_matched = 0;
+  bool is_occluded = false;
+  int occluded_len = 0;
+  int last_occluded_frame = -1;
+  bool was_recently_occluded = false;
+
+  std::vector<std::vector<double>> mean_history;
+
+private:
+  std::array<double, 4> tlwh_;
+  KalmanFilter *kalman_filter_;
+  std::vector<double> mean_;
+  Matrix covariance_;
+  double score_;
+  int tracklet_len_;
+  bool mean_valid_ = false;
+
+  friend class Fasttracker;
+};
+
+using STrackPtr = std::shared_ptr<STrack>;
+
+}  // namespace fasttracker
+

--- a/cpp/src/basetrack.cpp
+++ b/cpp/src/basetrack.cpp
@@ -1,0 +1,20 @@
+#include "fasttracker/basetrack.hpp"
+
+namespace fasttracker {
+
+namespace {
+int g_track_counter = 0;
+}
+
+BaseTrack::BaseTrack()
+    : track_id_(0), is_activated_(false), state_(TrackState::New),
+      start_frame_(0), frame_id_(0), time_since_update_(0) {}
+
+int BaseTrack::NextId() { return ++g_track_counter; }
+
+void BaseTrack::MarkLost() { state_ = TrackState::Lost; }
+
+void BaseTrack::MarkRemoved() { state_ = TrackState::Removed; }
+
+}  // namespace fasttracker
+

--- a/cpp/src/fasttracker.cpp
+++ b/cpp/src/fasttracker.cpp
@@ -1,0 +1,453 @@
+#include "fasttracker/fasttracker.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <unordered_map>
+
+namespace fasttracker {
+
+namespace {
+
+double ComputeIoU(const std::array<double, 4> &a,
+                  const std::array<double, 4> &b) {
+  double inter_x1 = std::max(a[0], b[0]);
+  double inter_y1 = std::max(a[1], b[1]);
+  double inter_x2 = std::min(a[2], b[2]);
+  double inter_y2 = std::min(a[3], b[3]);
+  double iw = std::max(0.0, inter_x2 - inter_x1);
+  double ih = std::max(0.0, inter_y2 - inter_y1);
+  double inter = iw * ih;
+  if (inter <= 0.0) {
+    return 0.0;
+  }
+  double area_a = (a[2] - a[0]) * (a[3] - a[1]);
+  double area_b = (b[2] - b[0]) * (b[3] - b[1]);
+  double denom = area_a + area_b - inter;
+  if (denom <= 0.0) {
+    return 0.0;
+  }
+  return inter / denom;
+}
+
+}  // namespace
+
+Fasttracker::Fasttracker(const FasttrackerArgs &args,
+                         const FasttrackerConfig &config, double frame_rate)
+    : args_(args), det_thresh_(config.track_thresh),
+      match_thresh_(config.match_thresh),
+      buffer_size_(static_cast<int>(frame_rate / 30.0 * config.track_buffer)),
+      max_time_lost_(buffer_size_),
+      reset_velocity_offset_occ_(config.reset_velocity_offset_occ),
+      reset_pos_offset_occ_(config.reset_pos_offset_occ),
+      enlarge_bbox_occ_(config.enlarge_bbox_occ),
+      dampen_motion_occ_(config.dampen_motion_occ),
+      active_occ_to_lost_thresh_(config.active_occ_to_lost_thresh),
+      init_iou_suppress_(config.init_iou_suppress) {
+  std::cout << "=== FastTracker Config ===\n";
+  std::cout << "  track_thresh: " << det_thresh_ << "\n";
+  std::cout << "  match_thresh: " << match_thresh_ << "\n";
+  std::cout << "  track_buffer: " << buffer_size_ << "\n";
+  std::cout << "  reset_velocity_offset_occ: " << reset_velocity_offset_occ_ << "\n";
+  std::cout << "  reset_pos_offset_occ: " << reset_pos_offset_occ_ << "\n";
+  std::cout << "  enlarge_bbox_occ: " << enlarge_bbox_occ_ << "\n";
+  std::cout << "  dampen_motion_occ: " << dampen_motion_occ_ << "\n";
+  std::cout << "  active_occ_to_lost_thresh: " << active_occ_to_lost_thresh_ << "\n";
+  std::cout << "  init_iou_suppress: " << init_iou_suppress_ << "\n";
+  std::cout << "=============================\n";
+}
+
+std::vector<std::shared_ptr<STrack>> Fasttracker::Update(
+    const std::vector<Detection> &output_results,
+    const std::array<int, 2> &img_info, const std::array<int, 2> &img_size) {
+  ++frame_id_;
+  std::vector<std::shared_ptr<STrack>> activated_stracks;
+  std::vector<std::shared_ptr<STrack>> refind_stracks;
+  std::vector<std::shared_ptr<STrack>> lost_stracks;
+  std::vector<std::shared_ptr<STrack>> removed_stracks;
+
+  std::vector<std::array<double, 4>> bboxes(output_results.size());
+  std::vector<double> scores(output_results.size(), 0.0);
+  for (std::size_t i = 0; i < output_results.size(); ++i) {
+    bboxes[i] = output_results[i].tlbr;
+    scores[i] = output_results[i].CombinedScore();
+  }
+
+  double img_h = static_cast<double>(img_info[0]);
+  double img_w = static_cast<double>(img_info[1]);
+  double scale = 1.0;
+  if (img_h > 0.0 && img_w > 0.0) {
+    scale = std::min(img_size[0] / img_h, img_size[1] / img_w);
+  }
+  if (scale > 0.0 && std::abs(scale - 1.0) > 1e-6) {
+    for (auto &bbox : bboxes) {
+      for (double &value : bbox) {
+        value /= scale;
+      }
+    }
+  }
+
+  std::vector<int> remain_inds;
+  std::vector<int> inds_low;
+  std::vector<int> inds_second;
+  for (std::size_t i = 0; i < scores.size(); ++i) {
+    if (scores[i] > det_thresh_) {
+      remain_inds.push_back(static_cast<int>(i));
+    }
+    if (scores[i] > 0.25) {
+      inds_low.push_back(static_cast<int>(i));
+    }
+    if (scores[i] < det_thresh_ && scores[i] > 0.25) {
+      inds_second.push_back(static_cast<int>(i));
+    }
+  }
+
+  std::vector<std::shared_ptr<STrack>> detections;
+  for (int idx : remain_inds) {
+    auto det = std::make_shared<STrack>(
+        STrack::TlbrToTlwh(bboxes[idx]), scores[idx]);
+    detections.push_back(det);
+  }
+
+  std::vector<std::shared_ptr<STrack>> detections_second;
+  for (int idx : inds_second) {
+    auto det = std::make_shared<STrack>(
+        STrack::TlbrToTlwh(bboxes[idx]), scores[idx]);
+    detections_second.push_back(det);
+  }
+
+  std::vector<std::shared_ptr<STrack>> unconfirmed;
+  std::vector<std::shared_ptr<STrack>> tracked_stracks;
+  for (const auto &track : tracked_stracks_) {
+    if (!track->is_activated_) {
+      unconfirmed.push_back(track);
+    } else {
+      tracked_stracks.push_back(track);
+    }
+  }
+
+  auto strack_pool = JointStracks(tracked_stracks, lost_stracks_);
+  STrack::MultiPredict(strack_pool);
+
+  Matrix dists = IouDistance(strack_pool, detections);
+  if (!args_.mot20) {
+    dists = FuseScore(dists, detections);
+  }
+  AssignmentResult matches = LinearAssignment(dists, match_thresh_);
+
+  for (const auto &pair : matches.matches) {
+    auto track = strack_pool[pair.first];
+    auto det = detections[pair.second];
+    if (track->state_ == TrackState::Tracked) {
+      track->Update(*det, frame_id_);
+      activated_stracks.push_back(track);
+    } else {
+      track->ReActivate(*det, frame_id_, false);
+      refind_stracks.push_back(track);
+    }
+    track->is_occluded = false;
+    track->not_matched = 0;
+    track->occluded_len = 0;
+  }
+
+  std::vector<int> unmatch_track = matches.unmatched_rows;
+  std::vector<int> unmatch_detection = matches.unmatched_cols;
+
+  std::vector<std::shared_ptr<STrack>> r_tracked_stracks;
+  std::vector<int> r_tracked_indices;
+  for (int idx : unmatch_track) {
+    if (strack_pool[idx]->state_ == TrackState::Tracked) {
+      r_tracked_indices.push_back(idx);
+      r_tracked_stracks.push_back(strack_pool[idx]);
+    }
+  }
+
+  Matrix dists_second = IouDistance(r_tracked_stracks, detections_second);
+  AssignmentResult matches_second =
+      LinearAssignment(dists_second, 0.5);
+  for (const auto &pair : matches_second.matches) {
+    auto track = r_tracked_stracks[pair.first];
+    auto det = detections_second[pair.second];
+    if (track->state_ == TrackState::Tracked) {
+      track->Update(*det, frame_id_);
+      activated_stracks.push_back(track);
+    } else {
+      track->ReActivate(*det, frame_id_, false);
+      refind_stracks.push_back(track);
+    }
+    track->is_occluded = false;
+    track->not_matched = 0;
+    track->occluded_len = 0;
+  }
+
+  std::vector<int> occlusion_candidates;
+  for (int idx : matches_second.unmatched_rows) {
+    occlusion_candidates.push_back(r_tracked_indices[idx]);
+  }
+
+  for (int idx : occlusion_candidates) {
+    auto track = strack_pool[idx];
+    track->not_matched += 1;
+    if (!track->is_occluded && track->state_ == TrackState::Tracked) {
+      for (const auto &other : activated_stracks) {
+        if (other->track_id() == track->track_id()) {
+          continue;
+        }
+        if (!other->is_activated_ || other->is_occluded) {
+          continue;
+        }
+        if (IsOccludedBy(track->Tlbr(), other->Tlbr(), 0.7)) {
+          track->is_occluded = true;
+          track->occluded_len += 1;
+          track->last_occluded_frame = frame_id_;
+          track->was_recently_occluded = true;
+
+          if (reset_velocity_offset_occ_ > 0 &&
+              track->mean_history.size() >=
+                  static_cast<std::size_t>(reset_velocity_offset_occ_)) {
+            const auto &old_mean = track->mean_history[
+                track->mean_history.size() - reset_velocity_offset_occ_];
+            for (int i = 4; i < 8; ++i) {
+              track->mean_[i] = old_mean[i];
+            }
+          }
+          if (reset_pos_offset_occ_ > 0 &&
+              track->mean_history.size() >=
+                  static_cast<std::size_t>(reset_pos_offset_occ_)) {
+            const auto &old_mean = track->mean_history[
+                track->mean_history.size() - reset_pos_offset_occ_];
+            for (int i = 0; i < 4; ++i) {
+              track->mean_[i] = old_mean[i];
+            }
+          }
+          if (track->occluded_len == 1 && track->mean_.size() >= 4) {
+            track->mean_[3] *= enlarge_bbox_occ_;
+          }
+          for (int i = 4; i < 8 && i < static_cast<int>(track->mean_.size());
+               ++i) {
+            track->mean_[i] *= dampen_motion_occ_;
+          }
+          break;
+        }
+      }
+    }
+
+    if (!track->is_occluded) {
+      track->occluded_len = 0;
+    } else {
+      track->occluded_len += 1;
+    }
+
+    if (track->was_recently_occluded &&
+        frame_id_ - track->last_occluded_frame > 40) {
+      track->was_recently_occluded = false;
+    }
+
+    if (track->state_ != TrackState::Lost) {
+      if (track->not_matched > 2 &&
+          (!track->is_occluded ||
+           track->occluded_len > active_occ_to_lost_thresh_)) {
+        track->MarkLost();
+        lost_stracks.push_back(track);
+      }
+    }
+  }
+
+  std::vector<std::shared_ptr<STrack>> detections_unmatched;
+  for (int idx : unmatch_detection) {
+    if (idx >= 0 && idx < static_cast<int>(detections.size())) {
+      detections_unmatched.push_back(detections[idx]);
+    }
+  }
+
+  Matrix dists_unconfirmed = IouDistance(unconfirmed, detections_unmatched);
+  if (!args_.mot20) {
+    dists_unconfirmed = FuseScore(dists_unconfirmed, detections_unmatched);
+  }
+  AssignmentResult matches_unconfirmed = LinearAssignment(dists_unconfirmed, 0.7);
+  for (const auto &pair : matches_unconfirmed.matches) {
+    auto track = unconfirmed[pair.first];
+    track->Update(*detections_unmatched[pair.second], frame_id_);
+    activated_stracks.push_back(track);
+  }
+  for (int idx : matches_unconfirmed.unmatched_rows) {
+    auto track = unconfirmed[idx];
+    track->MarkLost();
+    lost_stracks.push_back(track);
+  }
+
+  std::unordered_map<int, std::shared_ptr<STrack>> active_now_map;
+  for (const auto &track : tracked_stracks_) {
+    if (track->state_ == TrackState::Tracked) {
+      active_now_map[track->track_id()] = track;
+    }
+  }
+  for (const auto &track : activated_stracks) {
+    active_now_map[track->track_id()] = track;
+  }
+  std::vector<std::shared_ptr<STrack>> active_now;
+  active_now.reserve(active_now_map.size());
+  for (const auto &kv : active_now_map) {
+    active_now.push_back(kv.second);
+  }
+
+  for (int idx : matches_unconfirmed.unmatched_cols) {
+    auto track = detections_unmatched[idx];
+    if (track->score() < det_thresh_) {
+      continue;
+    }
+    std::array<double, 4> det_box = STrack::TlwhToTlbr(track->Tlwh());
+    double max_iou = 0.0;
+    for (const auto &active : active_now) {
+      max_iou = std::max(max_iou, ComputeIoU(det_box, active->Tlbr()));
+      if (max_iou >= init_iou_suppress_) {
+        break;
+      }
+    }
+    if (max_iou < init_iou_suppress_) {
+      track->Activate(&kalman_filter_, frame_id_);
+      activated_stracks.push_back(track);
+    }
+  }
+
+  for (const auto &track : lost_stracks_) {
+    bool recently_occluded =
+        track->was_recently_occluded &&
+        (frame_id_ - track->last_occluded_frame <= 40);
+    if (!recently_occluded &&
+        (frame_id_ - track->frame_id()) > max_time_lost_) {
+      track->MarkRemoved();
+      removed_stracks.push_back(track);
+    }
+  }
+
+  std::vector<std::shared_ptr<STrack>> tracked_tracked;
+  for (const auto &track : tracked_stracks_) {
+    if (track->state_ == TrackState::Tracked) {
+      tracked_tracked.push_back(track);
+    }
+  }
+
+  tracked_stracks_ = JointStracks(tracked_tracked, activated_stracks);
+  tracked_stracks_ = JointStracks(tracked_stracks_, refind_stracks);
+
+  lost_stracks_ = SubStracks(lost_stracks_, tracked_stracks_);
+  lost_stracks_.insert(lost_stracks_.end(), lost_stracks.begin(),
+                       lost_stracks.end());
+  lost_stracks_ = SubStracks(lost_stracks_, removed_stracks_);
+  removed_stracks_.insert(removed_stracks_.end(), removed_stracks.begin(),
+                          removed_stracks.end());
+
+  auto filtered = RemoveDuplicateStracks(tracked_stracks_, lost_stracks_);
+  tracked_stracks_ = filtered.first;
+  lost_stracks_ = filtered.second;
+
+  std::vector<std::shared_ptr<STrack>> output;
+  for (const auto &track : tracked_stracks_) {
+    if (track->is_activated_) {
+      output.push_back(track);
+    }
+  }
+  return output;
+}
+
+bool Fasttracker::IsOccludedBy(const std::array<double, 4> &a,
+                               const std::array<double, 4> &b,
+                               double iou_thresh) {
+  double inter_x1 = std::max(a[0], b[0]);
+  double inter_y1 = std::max(a[1], b[1]);
+  double inter_x2 = std::min(a[2], b[2]);
+  double inter_y2 = std::min(a[3], b[3]);
+  double iw = std::max(0.0, inter_x2 - inter_x1);
+  double ih = std::max(0.0, inter_y2 - inter_y1);
+  double inter = iw * ih;
+  double area_a = (a[2] - a[0]) * (a[3] - a[1]);
+  if (area_a <= 0.0) {
+    return false;
+  }
+  double iou = inter / area_a;
+  return iou > iou_thresh;
+}
+
+double Fasttracker::IoU(const std::array<double, 4> &a,
+                        const std::array<double, 4> &b) {
+  return ComputeIoU(a, b);
+}
+
+std::vector<std::shared_ptr<STrack>> JointStracks(
+    const std::vector<std::shared_ptr<STrack>> &a,
+    const std::vector<std::shared_ptr<STrack>> &b) {
+  std::unordered_map<int, std::shared_ptr<STrack>> exists;
+  std::vector<std::shared_ptr<STrack>> result;
+  result.reserve(a.size() + b.size());
+  for (const auto &track : a) {
+    exists[track->track_id()] = track;
+    result.push_back(track);
+  }
+  for (const auto &track : b) {
+    if (exists.find(track->track_id()) == exists.end()) {
+      exists[track->track_id()] = track;
+      result.push_back(track);
+    }
+  }
+  return result;
+}
+
+std::vector<std::shared_ptr<STrack>> SubStracks(
+    const std::vector<std::shared_ptr<STrack>> &a,
+    const std::vector<std::shared_ptr<STrack>> &b) {
+  std::unordered_map<int, std::shared_ptr<STrack>> track_map;
+  for (const auto &track : a) {
+    track_map[track->track_id()] = track;
+  }
+  for (const auto &track : b) {
+    track_map.erase(track->track_id());
+  }
+  std::vector<std::shared_ptr<STrack>> result;
+  result.reserve(track_map.size());
+  for (const auto &kv : track_map) {
+    result.push_back(kv.second);
+  }
+  return result;
+}
+
+std::pair<std::vector<std::shared_ptr<STrack>>,
+          std::vector<std::shared_ptr<STrack>>>
+RemoveDuplicateStracks(const std::vector<std::shared_ptr<STrack>> &a,
+                       const std::vector<std::shared_ptr<STrack>> &b) {
+  Matrix pdist = IouDistance(a, b);
+  std::vector<int> dup_a;
+  std::vector<int> dup_b;
+  for (std::size_t i = 0; i < pdist.rows(); ++i) {
+    for (std::size_t j = 0; j < pdist.cols(); ++j) {
+      if (pdist(i, j) < 0.15) {
+        int time_a = a[i]->frame_id() - a[i]->start_frame();
+        int time_b = b[j]->frame_id() - b[j]->start_frame();
+        if (time_a > time_b) {
+          dup_b.push_back(static_cast<int>(j));
+        } else {
+          dup_a.push_back(static_cast<int>(i));
+        }
+      }
+    }
+  }
+
+  std::vector<std::shared_ptr<STrack>> res_a;
+  std::vector<std::shared_ptr<STrack>> res_b;
+  for (std::size_t i = 0; i < a.size(); ++i) {
+    if (std::find(dup_a.begin(), dup_a.end(), static_cast<int>(i)) ==
+        dup_a.end()) {
+      res_a.push_back(a[i]);
+    }
+  }
+  for (std::size_t j = 0; j < b.size(); ++j) {
+    if (std::find(dup_b.begin(), dup_b.end(), static_cast<int>(j)) ==
+        dup_b.end()) {
+      res_b.push_back(b[j]);
+    }
+  }
+  return {res_a, res_b};
+}
+
+}  // namespace fasttracker
+

--- a/cpp/src/kalman_filter.cpp
+++ b/cpp/src/kalman_filter.cpp
@@ -1,0 +1,210 @@
+#include "fasttracker/kalman_filter.hpp"
+
+#include <cmath>
+#include <stdexcept>
+#include <string>
+
+namespace fasttracker {
+
+namespace {
+constexpr double kStdWeightPosition = 1.0 / 20.0;
+constexpr double kStdWeightVelocity = 1.0 / 160.0;
+
+const double kChi2Inv95Table[] = {
+    0.0,    3.8415, 5.9915, 7.8147, 9.4877,
+    11.070, 12.592, 14.067, 15.507, 16.919};
+
+Matrix BuildMotionMatrix() {
+  Matrix motion(8, 8);
+  for (int i = 0; i < 8; ++i) {
+    motion(i, i) = 1.0;
+  }
+  for (int i = 0; i < 4; ++i) {
+    motion(i, i + 4) = 1.0;
+  }
+  return motion;
+}
+
+Matrix BuildUpdateMatrix() {
+  Matrix update(4, 8);
+  for (int i = 0; i < 4; ++i) {
+    update(i, i) = 1.0;
+  }
+  return update;
+}
+
+}  // namespace
+
+KalmanFilter::KalmanFilter()
+    : motion_mat_(BuildMotionMatrix()), update_mat_(BuildUpdateMatrix()),
+      std_weight_position_(kStdWeightPosition),
+      std_weight_velocity_(kStdWeightVelocity) {}
+
+std::pair<std::vector<double>, Matrix> KalmanFilter::Initiate(
+    const std::vector<double> &measurement) const {
+  std::vector<double> mean_pos = measurement;
+  std::vector<double> mean_vel(mean_pos.size(), 0.0);
+  std::vector<double> mean(mean_pos.size() * 2, 0.0);
+  for (std::size_t i = 0; i < mean_pos.size(); ++i) {
+    mean[i] = mean_pos[i];
+    mean[i + mean_pos.size()] = mean_vel[i];
+  }
+
+  std::vector<double> std = {
+      2 * std_weight_position_ * measurement[3],
+      2 * std_weight_position_ * measurement[3],
+      1e-2,
+      2 * std_weight_position_ * measurement[3],
+      10 * std_weight_velocity_ * measurement[3],
+      10 * std_weight_velocity_ * measurement[3],
+      1e-5,
+      10 * std_weight_velocity_ * measurement[3]};
+  std::vector<double> variance(std.size());
+  for (std::size_t i = 0; i < std.size(); ++i) {
+    variance[i] = std[i] * std[i];
+  }
+  Matrix covariance = Diagonal(variance);
+  return {mean, covariance};
+}
+
+std::pair<std::vector<double>, Matrix> KalmanFilter::Predict(
+    const std::vector<double> &mean, const Matrix &covariance) const {
+  std::vector<double> std_pos = {
+      std_weight_position_ * mean[3],
+      std_weight_position_ * mean[3],
+      1e-2,
+      std_weight_position_ * mean[3]};
+  std::vector<double> std_vel = {
+      std_weight_velocity_ * mean[3],
+      std_weight_velocity_ * mean[3],
+      1e-5,
+      std_weight_velocity_ * mean[3]};
+
+  std::vector<double> concat;
+  concat.reserve(std_pos.size() + std_vel.size());
+  concat.insert(concat.end(), std_pos.begin(), std_pos.end());
+  concat.insert(concat.end(), std_vel.begin(), std_vel.end());
+
+  for (double &v : concat) {
+    v = v * v;
+  }
+  Matrix motion_cov = Diagonal(concat);
+
+  Matrix motion_t = Transpose(motion_mat_);
+  std::vector<double> new_mean = VecMat(mean, motion_t);
+  Matrix new_cov = MatMul(MatMul(motion_mat_, covariance), motion_t);
+  new_cov = Add(new_cov, motion_cov);
+
+  return {new_mean, new_cov};
+}
+
+std::pair<std::vector<std::vector<double>>, std::vector<Matrix>>
+KalmanFilter::MultiPredict(const std::vector<std::vector<double>> &means,
+                           const std::vector<Matrix> &covariances) const {
+  std::vector<std::vector<double>> new_means;
+  std::vector<Matrix> new_covs;
+  new_means.reserve(means.size());
+  new_covs.reserve(covariances.size());
+  for (std::size_t i = 0; i < means.size(); ++i) {
+    auto result = Predict(means[i], covariances[i]);
+    new_means.push_back(result.first);
+    new_covs.push_back(result.second);
+  }
+  return {new_means, new_covs};
+}
+
+ProjectedState KalmanFilter::Project(const std::vector<double> &mean,
+                                     const Matrix &covariance) const {
+  std::vector<double> std = {
+      std_weight_position_ * mean[3],
+      std_weight_position_ * mean[3],
+      1e-1,
+      std_weight_position_ * mean[3]};
+  std::vector<double> variance(std.size());
+  for (std::size_t i = 0; i < std.size(); ++i) {
+    variance[i] = std[i] * std[i];
+  }
+  Matrix innovation_cov = Diagonal(variance);
+
+  std::vector<double> projected_mean = MatVec(update_mat_, mean);
+  Matrix projected_cov = MatMul(MatMul(update_mat_, covariance),
+                                Transpose(update_mat_));
+  projected_cov = Add(projected_cov, innovation_cov);
+
+  return {projected_mean, projected_cov};
+}
+
+std::pair<std::vector<double>, Matrix> KalmanFilter::Update(
+    const std::vector<double> &mean, const Matrix &covariance,
+    const std::vector<double> &measurement) const {
+  ProjectedState proj = Project(mean, covariance);
+
+  Matrix gain_numerator = MatMul(covariance, Transpose(update_mat_));
+  Matrix innovation_cov_inv = Inverse(proj.covariance);
+  Matrix kalman_gain = MatMul(gain_numerator, innovation_cov_inv);
+
+  std::vector<double> innovation(measurement.size());
+  for (std::size_t i = 0; i < measurement.size(); ++i) {
+    innovation[i] = measurement[i] - proj.mean[i];
+  }
+
+  std::vector<double> mean_correction = MatVec(kalman_gain, innovation);
+  std::vector<double> new_mean = Add(mean, mean_correction);
+
+  Matrix temp = MatMul(kalman_gain, proj.covariance);
+  Matrix reduction = MatMul(temp, Transpose(kalman_gain));
+  Matrix new_covariance = Subtract(covariance, reduction);
+
+  return {new_mean, new_covariance};
+}
+
+std::vector<double> KalmanFilter::GatingDistance(
+    const std::vector<double> &mean, const Matrix &covariance,
+    const std::vector<std::vector<double>> &measurements, bool only_position,
+    const std::string &metric) const {
+  ProjectedState proj = Project(mean, covariance);
+  std::vector<double> local_mean = proj.mean;
+  Matrix local_cov = proj.covariance;
+
+  if (only_position) {
+    local_mean = {local_mean[0], local_mean[1]};
+    Matrix reduced(2, 2);
+    for (int r = 0; r < 2; ++r) {
+      for (int c = 0; c < 2; ++c) {
+        reduced(r, c) = local_cov(r, c);
+      }
+    }
+    local_cov = reduced;
+  }
+
+  Matrix inv_cov = Inverse(local_cov);
+  std::vector<double> result(measurements.size(), 0.0);
+  for (std::size_t i = 0; i < measurements.size(); ++i) {
+    std::vector<double> diff = measurements[i];
+    diff = Subtract(diff, local_mean);
+    if (only_position && diff.size() > 2) {
+      diff.resize(2);
+    }
+
+    if (metric == "maha" || metric.empty()) {
+      std::vector<double> intermediate = MatVec(inv_cov, diff);
+      result[i] = Dot(diff, intermediate);
+    } else if (metric == "gaussian") {
+      result[i] = Dot(diff, diff);
+    } else {
+      throw std::invalid_argument("Unknown gating metric");
+    }
+  }
+  return result;
+}
+
+double KalmanFilter::Chi2Inv95(int dof) {
+  if (dof < 1 || dof >= static_cast<int>(sizeof(kChi2Inv95Table) /
+                                         sizeof(kChi2Inv95Table[0]))) {
+    throw std::out_of_range("Chi2Inv95 table index out of range");
+  }
+  return kChi2Inv95Table[dof];
+}
+
+}  // namespace fasttracker
+

--- a/cpp/src/matching.cpp
+++ b/cpp/src/matching.cpp
@@ -1,0 +1,181 @@
+#include "fasttracker/matching.hpp"
+
+#include <algorithm>
+#include <limits>
+
+namespace fasttracker {
+
+namespace {
+
+double IoU(const std::array<double, 4> &a, const std::array<double, 4> &b) {
+  double ax1 = a[0];
+  double ay1 = a[1];
+  double ax2 = a[2];
+  double ay2 = a[3];
+  double bx1 = b[0];
+  double by1 = b[1];
+  double bx2 = b[2];
+  double by2 = b[3];
+
+  double inter_x1 = std::max(ax1, bx1);
+  double inter_y1 = std::max(ay1, by1);
+  double inter_x2 = std::min(ax2, bx2);
+  double inter_y2 = std::min(ay2, by2);
+  double iw = std::max(0.0, inter_x2 - inter_x1);
+  double ih = std::max(0.0, inter_y2 - inter_y1);
+  double inter = iw * ih;
+  if (inter <= 0.0) {
+    return 0.0;
+  }
+  double area_a = (ax2 - ax1) * (ay2 - ay1);
+  double area_b = (bx2 - bx1) * (by2 - by1);
+  double denom = area_a + area_b - inter;
+  if (denom <= 0.0) {
+    return 0.0;
+  }
+  return inter / denom;
+}
+
+Matrix BuildCost(const std::vector<std::array<double, 4>> &a,
+                 const std::vector<std::array<double, 4>> &b) {
+  Matrix cost(a.size(), b.size());
+  for (std::size_t i = 0; i < a.size(); ++i) {
+    for (std::size_t j = 0; j < b.size(); ++j) {
+      cost(i, j) = 1.0 - IoU(a[i], b[j]);
+    }
+  }
+  return cost;
+}
+
+}  // namespace
+
+Matrix IouDistance(const std::vector<std::shared_ptr<STrack>> &a,
+                   const std::vector<std::shared_ptr<STrack>> &b) {
+  std::vector<std::array<double, 4>> atlbrs;
+  std::vector<std::array<double, 4>> btlbrs;
+  atlbrs.reserve(a.size());
+  btlbrs.reserve(b.size());
+  for (const auto &track : a) {
+    atlbrs.push_back(track->Tlbr());
+  }
+  for (const auto &track : b) {
+    btlbrs.push_back(track->Tlbr());
+  }
+  return BuildCost(atlbrs, btlbrs);
+}
+
+Matrix IouDistance(const std::vector<std::array<double, 4>> &a,
+                   const std::vector<std::array<double, 4>> &b) {
+  return BuildCost(a, b);
+}
+
+AssignmentResult LinearAssignment(const Matrix &cost_matrix, double thresh) {
+  AssignmentResult result;
+  int rows = static_cast<int>(cost_matrix.rows());
+  int cols = static_cast<int>(cost_matrix.cols());
+  if (rows == 0 || cols == 0) {
+    for (int i = 0; i < rows; ++i) {
+      result.unmatched_rows.push_back(i);
+    }
+    for (int j = 0; j < cols; ++j) {
+      result.unmatched_cols.push_back(j);
+    }
+    return result;
+  }
+
+  int n = std::max(rows, cols);
+  std::vector<std::vector<double>> cost(n, std::vector<double>(n, thresh + 1.0));
+  for (int i = 0; i < rows; ++i) {
+    for (int j = 0; j < cols; ++j) {
+      cost[i][j] = cost_matrix(i, j);
+    }
+  }
+
+  std::vector<double> u(n + 1, 0.0), v(n + 1, 0.0);
+  std::vector<int> p(n + 1, 0), way(n + 1, 0);
+
+  for (int i = 1; i <= n; ++i) {
+    p[0] = i;
+    int j0 = 0;
+    std::vector<double> minv(n + 1, std::numeric_limits<double>::infinity());
+    std::vector<bool> used(n + 1, false);
+    do {
+      used[j0] = true;
+      int i0 = p[j0];
+      double delta = std::numeric_limits<double>::infinity();
+      int j1 = 0;
+      for (int j = 1; j <= n; ++j) {
+        if (used[j]) {
+          continue;
+        }
+        double cur = cost[i0 - 1][j - 1] - u[i0] - v[j];
+        if (cur < minv[j]) {
+          minv[j] = cur;
+          way[j] = j0;
+        }
+        if (minv[j] < delta) {
+          delta = minv[j];
+          j1 = j;
+        }
+      }
+      for (int j = 0; j <= n; ++j) {
+        if (used[j]) {
+          u[p[j]] += delta;
+          v[j] -= delta;
+        } else {
+          minv[j] -= delta;
+        }
+      }
+      j0 = j1;
+    } while (p[j0] != 0);
+    do {
+      int j1 = way[j0];
+      p[j0] = p[j1];
+      j0 = j1;
+    } while (j0 != 0);
+  }
+
+  std::vector<int> assignment(rows, -1);
+  for (int j = 1; j <= n; ++j) {
+    if (p[j] <= rows && j <= cols) {
+      assignment[p[j] - 1] = j - 1;
+    }
+  }
+
+  for (int i = 0; i < rows; ++i) {
+    int j = assignment[i];
+    if (j >= 0 && cost_matrix(i, j) <= thresh) {
+      result.matches.emplace_back(i, j);
+    } else {
+      result.unmatched_rows.push_back(i);
+    }
+  }
+  std::vector<bool> matched_cols(cols, false);
+  for (const auto &match : result.matches) {
+    matched_cols[match.second] = true;
+  }
+  for (int j = 0; j < cols; ++j) {
+    if (!matched_cols[j]) {
+      result.unmatched_cols.push_back(j);
+    }
+  }
+
+  return result;
+}
+
+Matrix FuseScore(const Matrix &cost_matrix,
+                 const std::vector<std::shared_ptr<STrack>> &detections) {
+  Matrix result(cost_matrix.rows(), cost_matrix.cols());
+  for (std::size_t i = 0; i < cost_matrix.rows(); ++i) {
+    for (std::size_t j = 0; j < cost_matrix.cols(); ++j) {
+      double iou_sim = 1.0 - cost_matrix(i, j);
+      double det_score = detections[j]->score();
+      double fuse_sim = iou_sim * det_score;
+      result(i, j) = 1.0 - fuse_sim;
+    }
+  }
+  return result;
+}
+
+}  // namespace fasttracker
+

--- a/cpp/src/strack.cpp
+++ b/cpp/src/strack.cpp
@@ -1,0 +1,153 @@
+#include "fasttracker/strack.hpp"
+
+#include <algorithm>
+
+namespace fasttracker {
+
+namespace {
+constexpr int kMaxHistory = 100;
+}
+
+STrack::STrack(const std::array<double, 4> &tlwh, double score)
+    : tlwh_(tlwh), kalman_filter_(nullptr), mean_(), covariance_(8, 8),
+      score_(score), tracklet_len_(0), mean_valid_(false) {}
+
+void STrack::Predict() {
+  if (!kalman_filter_ || !mean_valid_) {
+    return;
+  }
+  std::vector<double> mean_copy = mean_;
+  if (state_ != TrackState::Tracked && mean_copy.size() >= 8) {
+    mean_copy[7] = 0.0;
+  }
+  auto predicted = kalman_filter_->Predict(mean_copy, covariance_);
+  mean_ = predicted.first;
+  covariance_ = predicted.second;
+}
+
+void STrack::Activate(KalmanFilter *filter, int frame_id) {
+  kalman_filter_ = filter;
+  track_id_ = NextId();
+  auto initiated = kalman_filter_->Initiate(TlwhToXyah(tlwh_));
+  mean_ = initiated.first;
+  covariance_ = initiated.second;
+  mean_valid_ = true;
+
+  mean_history.push_back(mean_);
+  if (mean_history.size() > kMaxHistory) {
+    mean_history.erase(mean_history.begin());
+  }
+
+  tracklet_len_ = 0;
+  state_ = TrackState::Tracked;
+  is_activated_ = (frame_id == 1);
+  frame_id_ = frame_id;
+  start_frame_ = frame_id;
+}
+
+void STrack::ReActivate(const STrack &new_track, int frame_id, bool new_id) {
+  if (!kalman_filter_) {
+    kalman_filter_ = new_track.kalman_filter_;
+  }
+  auto updated = kalman_filter_->Update(
+      mean_, covariance_, TlwhToXyah(new_track.Tlwh()));
+  mean_ = updated.first;
+  covariance_ = updated.second;
+  mean_valid_ = true;
+
+  mean_history.push_back(mean_);
+  if (mean_history.size() > kMaxHistory) {
+    mean_history.erase(mean_history.begin());
+  }
+
+  tracklet_len_ = 0;
+  state_ = TrackState::Tracked;
+  is_activated_ = true;
+  frame_id_ = frame_id;
+  if (new_id) {
+    track_id_ = NextId();
+  }
+  score_ = new_track.score_;
+}
+
+void STrack::Update(const STrack &new_track, int frame_id) {
+  if (!kalman_filter_) {
+    kalman_filter_ = new_track.kalman_filter_;
+  }
+  frame_id_ = frame_id;
+  ++tracklet_len_;
+  auto updated = kalman_filter_->Update(
+      mean_, covariance_, TlwhToXyah(new_track.Tlwh()));
+  mean_ = updated.first;
+  covariance_ = updated.second;
+  mean_valid_ = true;
+
+  mean_history.push_back(mean_);
+  if (mean_history.size() > kMaxHistory) {
+    mean_history.erase(mean_history.begin());
+  }
+
+  state_ = TrackState::Tracked;
+  is_activated_ = true;
+  score_ = new_track.score_;
+}
+
+std::array<double, 4> STrack::Tlwh() const {
+  if (!mean_valid_) {
+    return tlwh_;
+  }
+  std::array<double, 4> ret = {mean_[0], mean_[1], mean_[2], mean_[3]};
+  ret[2] *= ret[3];
+  ret[0] -= ret[2] / 2.0;
+  ret[1] -= ret[3] / 2.0;
+  return ret;
+}
+
+std::array<double, 4> STrack::Tlbr() const {
+  std::array<double, 4> ret = Tlwh();
+  ret[2] += ret[0];
+  ret[3] += ret[1];
+  return ret;
+}
+
+std::array<double, 4> STrack::TlbrToTlwh(const std::array<double, 4> &tlbr) {
+  return {tlbr[0], tlbr[1], tlbr[2] - tlbr[0], tlbr[3] - tlbr[1]};
+}
+
+std::array<double, 4> STrack::TlwhToTlbr(const std::array<double, 4> &tlwh) {
+  return {tlwh[0], tlwh[1], tlwh[0] + tlwh[2], tlwh[1] + tlwh[3]};
+}
+
+std::vector<double> STrack::TlwhToXyah(const std::array<double, 4> &tlwh) {
+  std::vector<double> ret(tlwh.begin(), tlwh.end());
+  ret[0] += ret[2] / 2.0;
+  ret[1] += ret[3] / 2.0;
+  ret[2] = (ret[3] == 0.0) ? 0.0 : ret[2] / ret[3];
+  return ret;
+}
+
+void STrack::MultiPredict(const std::vector<std::shared_ptr<STrack>> &tracks) {
+  std::vector<std::vector<double>> means;
+  std::vector<Matrix> covariances;
+  std::vector<std::size_t> indices;
+  for (std::size_t i = 0; i < tracks.size(); ++i) {
+    if (tracks[i]->mean_valid_) {
+      means.push_back(tracks[i]->mean_);
+      covariances.push_back(tracks[i]->covariance_);
+      indices.push_back(i);
+    }
+  }
+  if (means.empty()) {
+    return;
+  }
+  KalmanFilter filter;
+  auto predicted = filter.MultiPredict(means, covariances);
+  for (std::size_t idx = 0; idx < indices.size(); ++idx) {
+    std::size_t track_index = indices[idx];
+    tracks[track_index]->mean_ = predicted.first[idx];
+    tracks[track_index]->covariance_ = predicted.second[idx];
+  }
+}
+
+}  // namespace fasttracker
+


### PR DESCRIPTION
## Summary
- implement a standalone C++ port of the FastTracker core, including Kalman filter, track management, data association, and occlusion logic
- provide supporting linear algebra utilities, configuration structures, and matching helpers along with a CMake build target
- add a gitignore entry to keep the generated CMake build directory out of version control

## Testing
- cmake -S cpp -B cpp/build
- cmake --build cpp/build


------
https://chatgpt.com/codex/tasks/task_e_68d526c6969c83319edb4ce1425a21bd